### PR TITLE
Changing currency name from "Durk Coin" to "Lunar Fragment".

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
+++ b/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
@@ -5,8 +5,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-server-currency-name-singular = Durk Coin
-server-currency-name-plural = Durk Coins
+server-currency-name-singular = Lunar Fragment
+server-currency-name-plural = Lunar Fragments
 
 ## Commands
 


### PR DESCRIPTION
Changing "Durk Coin" to "Lunar Fragment".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the server currency name in English to "Lunar Fragment" (singular) and "Lunar Fragments" (plural).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->