### PR TITLE
Adds and refines Cuptain related content, including a plastic sword.

### DIFF
--- a/Resources/Locale/en-US/job/job-description.ftl
+++ b/Resources/Locale/en-US/job/job-description.ftl
@@ -38,6 +38,7 @@ job-description-boxer = Fight your way to the top! Challenge the head of personn
 job-description-brigmedic = Fight in the rear of the security service, for the lives of your comrades! You are the first and last hope of your squad. Hippocrates bless you.
 job-description-cadet = Learn the basics of arresting criminals and managing the brig. Listen to your supervisors and feel free to ask them for any help.
 job-description-captain = Keep the station running, delegate work to the other heads of staff, and exert your will.
+job-description-cuptain = Keep the station running, delegate work to the other heads of staff, and exert your will. At least, that's what you want people to think your job is. 
 job-description-cargotech = Deal with requisitions and deliveries, pilot the cargo shuttle to the trade station and back, and work with others to make ludicrous amounts of cash and then waste it all gambling.
 job-description-ce = Manage the engineering department to ensure power, atmospherics, and the hull are in perfect shape.
 job-description-centcomoff = Act as an ambassador to the newest state-of-the-art space station in Nanotrasen's fleet.

--- a/Resources/Locale/en-US/job/job-names.ftl
+++ b/Resources/Locale/en-US/job/job-names.ftl
@@ -33,6 +33,7 @@
 job-name-warden = Warden
 job-name-security = Security Officer
 job-name-cadet = Security Cadet
+job-name-cuptain = Cuptain
 job-name-hos = Head of Security
 job-name-detective = Detective
 job-name-brigmedic = Brigmedic
@@ -115,6 +116,7 @@ JobChemist = Chemist
 JobChiefEngineer = Chief Engineer
 JobChiefMedicalOfficer = Chief Medical Officer
 JobClown = Clown
+JobCuptain = Cuptain
 JobDetective = Detective
 JobBrigmedic = Brigmedic
 JobERTChaplain = ERT Chaplain

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -690,12 +690,48 @@
         whitelist:
           tags:
           - CaptainSabre
+          - CaptainFake
   - type: ItemMapper
     mapLayers:
       sheath-sabre:
         whitelist:
           tags:
           - CaptainSabre
+          - CaptainSabreFake
+  - type: Appearance
+
+- type: entity
+  parent: [ClothingBeltBase, ClothingSlotBase]
+  id: ClothingBeltSheathFake
+  name: plastic sabre sheath
+  description: An plastic sheath designed to cosplay an officer.
+  components:
+  - type: Sprite
+    sprite: Clothing/Belt/sheath.rsi
+    state: sheath
+  - type: Clothing
+    sprite: Clothing/Belt/sheath.rsi
+  - type: Item
+    size: Ginormous
+  - type: ItemSlots
+    slots:
+      item:
+        name: Sabre
+        insertVerbText: sheath-insert-verb
+        ejectVerbText: sheath-eject-verb
+        insertSound: /Audio/Items/sheath.ogg
+        ejectSound: /Audio/Items/unsheath.ogg
+        whitelist:
+          tags:
+          - CaptainSabre
+          - CaptainSabreFake
+  - type: ItemMapper
+    mapLayers:
+      sheath-sabre:
+        whitelist:
+          tags:
+          - CaptainSabre
+          - CaptainSabreFake
   - type: Appearance
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -242,8 +242,8 @@
 - type: entity
   parent: ClothingHandsBase
   id: ClothingHandsGlovesCaptainFake
-  name: captain gloves
-  description: Regal blue gloves, with a foil gold trim. They feel cheap.
+  name: cuptain gloves
+  description: Regal blue gloves, with a foil gold trim. They look like repurposed budget insuls.
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/captain.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -1228,7 +1228,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatCapcapFake
-  name: cup cap
+  name: cuptain cap
   description: A grand, stylish cuptain cap made of the finest arts and crafts materials.
   components:
   - type: Sprite
@@ -1246,21 +1246,6 @@
     flavorKind: station-event-random-sentience-flavor-inanimate
     weight: 0.1
   - type: BlockMovement
-  - type: Armor # Goob
-    coverage:
-    - Head
-    traumaDeductions:
-      Dismemberment: 0.2
-      OrganDamage: 0.2
-      BoneDamage: 0.2
-      VeinsDamage: 0
-      NerveDamage: 0
-    modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
 
 - type: entity
   parent: [ ClothingHeadBase, BaseCentcommContraband ]

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/roles.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/roles.yml
@@ -691,3 +691,14 @@
       state: banner-yellow
     - type: RandomHumanoidSpawner
       settings: Cossack
+
+
+- type: entity
+  id: RandomHumanoidVisitorCaptainFake
+  name: visiting Cuptain ghost role
+  components:
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      state: captain
+    - type: RandomHumanoidSpawner
+      settings: VisitorCaptainFake

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -876,3 +876,14 @@
     - type: Loadout
       prototypes: [ CossackGear ]
       roleLoadout: [ RoleSurvivalEVA ]
+
+- type: randomHumanoidSettings
+  id: VisitorCaptainFake
+  parent: VisitorHead
+  components:
+    - type: GhostRole
+      name: job-name-cuptain
+      description: job-description-cuptain
+    - type: Loadout
+      prototypes: CaptainFake
+      roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/spawners.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/spawners.yml
@@ -1048,3 +1048,17 @@
   - type: RandomSpawner
     prototypes:
     - RandomHumanoidCossack
+
+- type: entity
+  name: visiting cuptain spawner
+  id: VisitorCaptainFakeSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Decoration/banner.rsi
+        state: banner
+  - type: RandomSpawner
+    prototypes:
+    - RandomHumanoidVisitorCaptainFake

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -372,8 +372,8 @@
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeyStationMasterFake
-  name: station master encryption key
-  description: An encryption key used by station's bosses.
+  name: cuptain encryption key
+  description: An encryption key that you can still see the glue on.
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -196,6 +196,39 @@
     # not putting a BlockMovement component here cause that's funny.
 
 - type: entity
+  name: cuptain's plastic sword
+  parent: BaseSword
+  id: CaptainSabreFake
+  description: A plastic replication of a captain's sword. Careful, the edge may cut by accident.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/captain_sabre.rsi
+  - type: MeleeWeapon
+    animationRotation: -95 # WWDP
+    wideAnimationRotation: -135 # WWDP
+    heavyStaminaCost: 2.5 # goob edit
+    attackRate: 1.5
+    damage:
+      types:
+        Slash: 1 #cmon, it has to be at least BETTER than the rest. # Goob edit
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect # change this and i will fucking GUT YOU. YOU HEAR ME AVIU??
+    reflectProb: .05
+    spread: 90
+  - type: Item
+    sprite: Objects/Weapons/Melee/captain_sabre.rsi
+  - type: Tag
+    tags:
+    - CaptainSabre
+  - type: DisarmMalus
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-inanimate
+    weight: 0.1 # 5,000 times less likely than 1 regular animal
+  - type: PirateAccent
+    # not putting a BlockMovement component here cause that's funny.
+
+- type: entity
   name: katana
   parent: [ BaseSword, BaseMajorContraband ]
   id: Katana

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -83,8 +83,9 @@
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone
   goobcoins: 0 #Goob content
- # access:
- #  - Maintenance
+  access:
+  - Maintenance
+
 
 - type: startingGear
   id: PassengerGear

--- a/Resources/Prototypes/Roles/Jobs/Fun/cuptain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/cuptain.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+#
+# SPDX-License-Identifier: MIT
+
+- type: job # goob edit
+  id: Cuptain
+  name: job-name-cuptain
+  description: job-description-cuptain
+  playTimeTracker: JobCuptain
+  startingGear: CaptainFakeGear
+  icon: "JobIconCaptain"
+  supervisors: job-supervisors-everyone
+  goobcoins: 2 #Goob content
+  access:
+  - Maintenance
+
+
+- type: startingGear
+  id: CaptainFakeGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCaptainFake
+    shoes: ClothingShoesBootsLaceup
+    eyes: ClothingEyesGlassesCheapSunglasses
+    gloves: ClothingHandsGlovesCaptainFake
+    head: ClothingHeadHatCaptainFake
+    id: CaptainPDAFake
+    back: ClothingBackpackCaptainFake
+    belt: ClothingBeltSheathFake
+    ears: ClothingHeadsetCommandFake
+    pocket1: PlushieCuptain

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1920,15 +1920,3 @@
     head: ClothingHeadHatGreyFlatcap
     id: VisitorPDA
     back: ClothingBackpack
-
-- type: startingGear
-  id: CaptainFake
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitCaptainFake
-    shoes: ClothingShoesBootsLaceup
-    eyes: ClothingEyesGlassesCheapSunglasses
-    gloves: ClothingHandsGlovesCaptainFake
-    head: ClothingHeadHatCaptainFake
-    id: CaptainPDAFake
-    back: ClothingBackpackCaptainFake
-    ears: ClothingHeadsetCommandFake


### PR DESCRIPTION
You know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the "Cuptain" job, complete with unique name, description, and dedicated starting gear themed around a playful, imitation captain.
  - Added new items for the Cuptain role, including a plastic sword, gloves, cap, sheath, and encryption key with distinct names and descriptions.
  - Implemented a visiting Cuptain ghost role and corresponding spawner for special events or visitor scenarios.

- **Improvements**
  - "Passenger" job now has maintenance access enabled.

- **Adjustments**
  - Updated descriptions and names for various Cuptain-themed items to better reflect their parody nature.
  - Removed armor from the Cuptain cap for balance.
  - Retired an unused starting gear set for the fake captain role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->